### PR TITLE
fix compilation by importing System.IO.Unsafe

### DIFF
--- a/System/Gnu/CryptR.hsc
+++ b/System/Gnu/CryptR.hsc
@@ -46,6 +46,8 @@ import Foreign
 import Foreign.C.String
 import Foreign.C.Types
 
+import System.IO.Unsafe
+
 #include <crypt.h>
 
 -- An empty data type to represent the c struct crypt_data


### PR DESCRIPTION
System/Gnu/CryptR.hsc needs import System.IO.Unsafe to be able to do unsafePerformIO.
